### PR TITLE
CU-86c7n9ta3-upgrade-dbt-version-to-1.11

### DIFF
--- a/airflow/.env
+++ b/airflow/.env
@@ -1,0 +1,2 @@
+AIRFLOW_IMAGE_NAME=apache/airflow:3.1.6-python3.10
+AIRFLOW_UID=50000

--- a/airflow/Dockerfile
+++ b/airflow/Dockerfile
@@ -1,3 +1,3 @@
-FROM apache/airflow:2.9.3-python3.9
+FROM apache/airflow:3.1.6-python3.10
 COPY requirements.txt .
 RUN pip install -r requirements.txt

--- a/airflow/docker-compose.yml
+++ b/airflow/docker-compose.yml
@@ -50,7 +50,7 @@ x-airflow-common:
   # Comment the image line, place your Dockerfile in the directory where you placed the docker-compose.yaml
   # and uncomment the "build" line below, Then run `docker-compose build` to build the images.
 
-  image: ${AIRFLOW_IMAGE_NAME:-dbt-cosmos:latest}
+  image: ${AIRFLOW_IMAGE_NAME:-dbt-cosmos-1.11:latest}
   # build: .
   environment:
     &airflow-common-env
@@ -116,9 +116,9 @@ services:
       start_period: 30s
     restart: always
 
-  airflow-webserver:
+  airflow-api-server:
     <<: *airflow-common
-    command: webserver
+    command: api-server
     ports:
       - "8080:8080"
     healthcheck:

--- a/airflow/requirements.txt
+++ b/airflow/requirements.txt
@@ -1,3 +1,3 @@
-dbt-core==1.8.2
-dbt-bigquery==1.8.1
-astronomer-cosmos>=1.0.2
+dbt-core==1.11.2
+dbt-bigquery==1.11.0
+astronomer-cosmos==1.12.0

--- a/package-lock.yml
+++ b/package-lock.yml
@@ -1,14 +1,20 @@
 packages:
-  - package: calogica/dbt_expectations
-    version: 0.10.3
-  - package: dbt-labs/dbt_utils
-    version: 1.2.0
-  - package: dbt-labs/codegen
-    version: 0.12.1
-  - package: dbt-labs/audit_helper
-    version: 0.12.1
-  - package: dbt-labs/dbt_project_evaluator
-    version: 1.0.0
-  - package: calogica/dbt_date
-    version: 0.10.1
-sha1_hash: 26faa2411d5d8c13a91dc9c4fd4d71fe56c87184
+  - name: dbt_expectations
+    package: metaplane/dbt_expectations
+    version: 0.10.10
+  - name: dbt_utils
+    package: dbt-labs/dbt_utils
+    version: 1.3.3
+  - name: codegen
+    package: dbt-labs/codegen
+    version: 0.14.0
+  - name: audit_helper
+    package: dbt-labs/audit_helper
+    version: 0.12.2
+  - name: dbt_project_evaluator
+    package: dbt-labs/dbt_project_evaluator
+    version: 1.1.2
+  - name: dbt_date
+    package: godatadriven/dbt_date
+    version: 0.17.1
+sha1_hash: c88ef1b18688300ac3809b72da7172b15405b279

--- a/packages.yml
+++ b/packages.yml
@@ -1,15 +1,15 @@
 packages:
-  - package: calogica/dbt_expectations
-    version: 0.10.3
+  - package: metaplane/dbt_expectations
+    version: 0.10.10
 
   - package: dbt-labs/dbt_utils
-    version: 1.2.0
+    version: 1.3.3
 
   - package: dbt-labs/codegen
-    version: 0.12.1
+    version: 0.14.0
 
   - package: dbt-labs/audit_helper
-    version: 0.12.1
+    version: 0.12.2
 
   - package: dbt-labs/dbt_project_evaluator
-    version: 1.0.0
+    version: 1.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-dbt-core==1.8.2
-dbt-bigquery==1.8.1
-sqlfluff==3.2.3
-sqlfluff-templater-dbt==3.2.3
+dbt-core==1.11.2
+dbt-bigquery==1.11.0
+sqlfluff==4.0.0
+sqlfluff-templater-dbt==4.0.0
 yamllint==1.35.1
 pylint==3.3.1
 pymarkdownlnt==0.9.24

--- a/terraform/cloud-composer.tf
+++ b/terraform/cloud-composer.tf
@@ -38,11 +38,11 @@ resource "google_composer_environment" "cloud_composer" {
   name = "cloud-composer"
   config {
     software_config {
-      image_version = "composer-2.8.7-airflow-2.7.3"
+      image_version = "composer-3-airflow-3.1.0"
       pypi_packages = {
-        dbt-core = "==1.8.2"
-        dbt-bigquery = "==1.8.1"
-        astronomer-cosmos = ">=1.0.2"
+        dbt-core = "==1.11.2"
+        dbt-bigquery = "==1.11.0"
+        astronomer-cosmos = "==1.12.0"
         }
     }
     node_config {


### PR DESCRIPTION
 ℹ️ dbt version 1.8.0 has been deprecated (https://docs.getdbt.com/docs/dbt-versions/upgrade-dbt-version-in-cloud#latest-releases) therefore it needs update to one that is currently supported

<img width="713" height="319" alt="Screenshot 2026-01-19 at 23 56 45" src="https://github.com/user-attachments/assets/e2c79e68-d3f2-4230-8005-b21f21c5c269" />

This has involved 3 major steps: 

✅ update dbt-local version + compatible sqlfluff package --- [07c2f71](https://github.com/ateneva/dbt-data-transformations/pull/4/commits/07c2f715438158d079e5f68b073340a527cd8b24)

✅ update the local airflow image to correspond to the version used locally + use a compatible cosmos implementation and use airflow 3 --- [98790b3](https://github.com/ateneva/dbt-data-transformations/pull/4/commits/98790b3d663c8dea4e3db338427baa1e5ec35126)

✅ update the cloud composer instance with to use upgrade dbt version +  compatible cosmos implementation and use airflow 3 --- [3f153bf](https://github.com/ateneva/dbt-data-transformations/pull/4/commits/3f153bf44a34952fd8496d0b43020079cbb8d73b)